### PR TITLE
[feat] 대시보드 통신 api 1차 구현 (#31)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/supabase-js": "^2.55.0",
         "@tailwindcss/postcss": "^4.1.12",
         "clsx": "2.1.1",
+        "fractional-indexing": "^3.2.0",
         "gsap": "3.13.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -4533,6 +4534,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fractional-indexing": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fractional-indexing/-/fractional-indexing-3.2.0.tgz",
+      "integrity": "sha512-PcOxmqwYCW7O2ovKRU8OoQQj2yqTfEB/yeTYk4gPid6dN5ODRfU1hXd9tTVZzax/0NkO7AxpHykvZnT1aYp/BQ==",
+      "license": "CC0-1.0",
+      "engines": {
+        "node": "^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/fresh": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@supabase/supabase-js": "^2.55.0",
     "@tailwindcss/postcss": "^4.1.12",
     "clsx": "2.1.1",
+    "fractional-indexing": "^3.2.0",
     "gsap": "3.13.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/src/pages/DashBoard/api/dragUpdate.ts
+++ b/src/pages/DashBoard/api/dragUpdate.ts
@@ -1,0 +1,105 @@
+import { supabase } from "@/lib/supabaseClient";
+import { generateKeyBetween } from "fractional-indexing";
+import { createJitter } from "../utils/createJitter";
+
+// 기존 PlanItem 타입 재사용
+export interface PlanItem {
+  id: string;
+  group_id: string;
+  title: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  sort_order: string;
+  duration: number;
+  day: string;
+}
+
+// 드래그 앤 드롭용 확장 타입
+export interface DraggedPlanItem extends PlanItem {
+  dragged?: boolean; // 드래그된 아이템 표시용
+}
+
+// API 요청 파라미터
+export interface UpdatePlanItemOrderParams {
+  itemId: string;
+  groupId: string;
+  day: string; // 'YYYY-MM-DD' format
+  currentItems: DraggedPlanItem[]; // 드래그 완료된 최종 리스트
+}
+
+
+export async function dragUpdate({
+  itemId,
+  groupId,
+  day,
+  currentItems
+}: UpdatePlanItemOrderParams): Promise<PlanItem> {
+  try {
+    //  입력 검증
+    if (!itemId || !groupId || !day || !currentItems || currentItems.length === 0) {
+      throw new Error('필수 파라미터가 누락되었습니다.');
+    }
+
+    // 드래그된 아이템의 새 위치 찾기
+    const draggedIndex = currentItems.findIndex(item => item.dragged === true);
+    
+    if (draggedIndex === -1) {
+      throw new Error('dragged 플래그가 설정된 아이템을 찾을 수 없습니다.');
+    }
+
+    const draggedItem = currentItems[draggedIndex];
+    
+    // 보안 체크: 해당 아이템이 실제로 요청한 itemId와 일치하는지
+    if (draggedItem.id !== itemId) {
+      throw new Error('드래그된 아이템 ID가 일치하지 않습니다.');
+    }
+
+    // 앞뒤 아이템의 sort_order 추출
+    const prevItem = currentItems[draggedIndex - 1];
+    const nextItem = currentItems[draggedIndex + 1];
+    
+    const prevSortOrder = prevItem?.sort_order || null;
+    const nextSortOrder = nextItem?.sort_order || null;
+
+    // console.log(`🎯 아이템 "${draggedItem.title}" 이동:`);
+    // console.log(`   위치: ${draggedIndex}`);
+    // console.log(`   이전: ${prevSortOrder}`);
+    // console.log(`   다음: ${nextSortOrder}`);
+
+    // 새로운 sort_order 생성 
+    const baseKey = generateKeyBetween(prevSortOrder, nextSortOrder);
+    const finalKey = `${baseKey}_${createJitter()}`;
+
+    if (!finalKey) {
+      throw new Error('sort_order 생성에 실패했습니다.');
+    }
+
+    console.log(`새로운 sort_order: ${finalKey}`);
+
+    // Supabase 업데이트
+    const { data, error } = await supabase
+      .from('planitems')
+      .update({ sort_order: finalKey })
+      .eq('id', itemId)
+      .eq('group_id', groupId) 
+      .eq('day', day)         
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Supabase 업데이트 실패: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error('업데이트할 아이템을 찾을 수 없습니다. (권한 또는 존재하지 않는 아이템)');
+    }
+
+    console.log('✅ Plan item order updated successfully');
+    return data;
+
+  } catch (error) {
+    console.error('❌ Error updating plan item order:', error);
+    throw error;
+  }
+}

--- a/src/pages/DashBoard/api/editUpdate.ts
+++ b/src/pages/DashBoard/api/editUpdate.ts
@@ -1,0 +1,79 @@
+import { supabase } from "@/lib/supabaseClient";
+
+// 기존 PlanItem 타입 재사용
+export interface PlanItem {
+  id: string;
+  group_id: string;
+  title: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  sort_order: string;
+  duration: number;
+  day: string;
+}
+
+// 편집 업데이트용 파라미터
+export interface UpdatePlanItemParams {
+  itemId: string;
+  groupId: string;
+  day: string; // 'YYYY-MM-DD' format
+  title: string;
+  duration: number;
+}
+
+
+export async function editUpdate({
+  itemId,
+  groupId,
+  day,
+  title,
+  duration
+}: UpdatePlanItemParams): Promise<PlanItem> {
+  try {
+    if (!itemId || !groupId || !day) {
+      throw new Error('필수 파라미터 (itemId, groupId, day)가 누락되었습니다.');
+    }
+
+    if (!title || title.trim().length === 0) {
+      throw new Error('타이틀은 필수입니다.');
+    }
+
+    if (duration <= 0 && duration > 24) {
+      throw new Error('듀레이션은 0보다 크고 24보다 작아야 합니다.');
+    }
+
+    // console.log(`🔧 Plan Item 편집:`);
+    // console.log(`   ID: ${itemId}`);
+    // console.log(`   제목: ${title}`);
+    // console.log(`   시간: ${duration}분`);
+
+    // Supabase 업데이트
+    const { data, error } = await supabase
+      .from('planitems')
+      .update({ 
+        title: title.trim(),
+        duration 
+      })
+      .eq('id', itemId)
+      .eq('group_id', groupId) 
+      .eq('day', day)         
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Supabase 업데이트 실패: ${error.message}`);
+    }
+
+    if (!data) {
+      throw new Error('업데이트할 아이템을 찾을 수 없습니다. (권한 또는 존재하지 않는 아이템)');
+    }
+
+    console.log('✅ Plan item updated successfully');
+    return data;
+
+  } catch (error) {
+    console.error('❌ Error updating plan item:', error);
+    throw error;
+  }
+}

--- a/src/pages/DashBoard/api/insertPlanItem.ts
+++ b/src/pages/DashBoard/api/insertPlanItem.ts
@@ -1,0 +1,84 @@
+import { supabase } from "@/lib/supabaseClient";
+import { generateKeyBetween } from "fractional-indexing";
+import { createJitter } from "../utils/createJitter";
+
+export interface PlanItemInsert {
+  group_id: string;
+  title: string;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  duration?: number;
+  day: string; // 'YYYY-MM-DD' format
+}
+
+export interface PlanItem {
+  id: string;
+  group_id: string;
+  title: string;
+  address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  sort_order: string;
+  duration: number;
+  day: string;
+}
+
+export async function insertPlanItem(
+  item: PlanItemInsert, 
+  cachedItems?: PlanItem[] // 이미 특정 day로 필터링되고 정렬된 리스트
+): Promise<PlanItem> {
+  try {
+    let lastSortOrder: string | null = null;
+
+    // 캐시 활용 
+    if (cachedItems && cachedItems.length > 0) {
+      lastSortOrder = cachedItems[cachedItems.length - 1].sort_order;
+    } else {
+      // 캐시에 없으면 DB 조회
+      console.log('캐시된 데이터가 없으므로 DB에서 마지막 인덱스를 가져오겠습니다.');
+      const { data: lastItem, error: queryError } = await supabase
+        .from('planitems')
+        .select('sort_order')
+        .eq('group_id', item.group_id)
+        .eq('day', item.day)
+        .order('sort_order', { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (queryError) {
+        throw new Error(`Failed to query last item: ${queryError.message}`);
+      }
+
+      lastSortOrder = lastItem?.sort_order || null;
+    }
+
+    // Fractional index + 지터로 새 키 생성
+    const baseKey = generateKeyBetween(lastSortOrder, null);
+    const finalKey = `${baseKey}_${createJitter()}`;
+
+    const newItem = {
+      ...item,
+      sort_order: finalKey,
+      duration: item.duration || 120 // 기본값 2시간
+    };
+
+    // DB에 삽입
+    const { data, error } = await supabase
+      .from('planitems')
+      .insert(newItem)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(`Failed to insert plan item: ${error.message}`);
+    }
+
+    console.log('✅ Plan item inserted successfully');
+    return data;
+
+  } catch (error) {
+    console.error('Error inserting plan item:', error);
+    throw error;
+  }
+}

--- a/src/pages/DashBoard/api/loadGroupData.ts
+++ b/src/pages/DashBoard/api/loadGroupData.ts
@@ -1,0 +1,24 @@
+import {supabase} from "@/lib/supabaseClient"
+
+export interface Group {
+id: string;
+name: string;
+owner_id: string;
+start_day: string; // 'YYYY-MM-DD' format
+end_day: string;   // 'YYYY-MM-DD' format
+}
+
+export async function loadGroupData(groupId: string): Promise<Group | null> {
+ const { data, error } = await supabase
+   .from('groups')
+   .select('*')
+   .eq('id', groupId)
+   .single();
+
+ if (error) {
+   console.error('그룹 데이터를 가져오는데 에러가 발생하였습니다. :', error);
+   return null;
+ }
+
+ return data as Group;
+}

--- a/src/pages/DashBoard/api/loadPlanItem.ts
+++ b/src/pages/DashBoard/api/loadPlanItem.ts
@@ -1,0 +1,29 @@
+import {supabase} from "@/lib/supabaseClient"
+
+export interface PlanItem {
+ id: string;
+ group_id: string;
+ title: string;
+ address: string | null;
+ latitude: number | null;
+ longitude: number | null;
+ sort_order: number;
+ duration: number;
+ day: string; // 'YYYY-MM-DD' format
+}
+
+export async function loadPlanItemsByDay(groupId: string, day: string): Promise<PlanItem[] | null> {
+  const { data, error } = await supabase
+    .from('planitems')
+    .select('*')
+    .eq('group_id', groupId)
+    .eq('day', day)
+    .order('sort_order');
+    
+  if (error) {
+    console.error('Error loading plan items:', error);
+    return null;
+  }
+    
+  return data as PlanItem[];
+}

--- a/src/pages/DashBoard/utils/createJitter.ts
+++ b/src/pages/DashBoard/utils/createJitter.ts
@@ -1,0 +1,3 @@
+export function createJitter(): string {
+  return `${Date.now()}_${Math.random().toString(36).substring(2, 6)}`; // 3자리 지터
+}


### PR DESCRIPTION
## 🌟 작업 개요
- 대시보드에서 이루어지는 api 통신 로직을 미리 구현했습니다. (기본적인 흐름을 잡고자..)

- 다음과 같은 통신 로직이 추가되었습니다.
**1. 데이터 로드**
1-1. groups 데이터
1-2. planitems 데이터

**2. 데이터 삽입**

**3. 데이터 업데이트**
3-1. 드래그에 의한 업데이트
3-2. edit에 의한 업데이트

- fractional-indexing
: fractional indexing을 위해 라이브러리를 추가했습니다!

# npm i 를 꼭 하십시오.

## 📝 작업 내용
- DashBoard의 하위 폴더로 api, utils를 만들고 CRUD에 따라 각 통신을 구분지어 파일로 만들었습니다. 

## ‼️ 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #22 