### PR TITLE
[feat] 대시보드 일정 리스트 dnd 구현 (#4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "planmingo",
       "version": "0.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@dr.pogodin/react-helmet": "^3.0.2",
         "@googlemaps/react-wrapper": "^1.2.0",
         "@supabase/supabase-js": "^2.55.0",
@@ -363,6 +366,59 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@dr.pogodin/react-helmet": {
@@ -7687,7 +7743,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/tsscmp": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@dr.pogodin/react-helmet": "^3.0.2",
     "@googlemaps/react-wrapper": "^1.2.0",
     "@supabase/supabase-js": "^2.55.0",

--- a/src/pages/DashBoard/components/PlanItem.tsx
+++ b/src/pages/DashBoard/components/PlanItem.tsx
@@ -1,0 +1,44 @@
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import dragIcon from "@/assets/icons/drag_indicator_icon.png";
+import deleteIcon from "@/assets/icons/delete_icon.png";
+import editIcon from "@/assets/icons/edit_icon.png";
+
+interface Props {
+  index: number;
+  content: string;
+  hour: number;
+}
+
+function PlanItem({ index, content, hour }: Props) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: String(index) });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <li ref={setNodeRef} style={style}>
+      <article className="h-[60px] pr-2 flex items-center gap-2 rounded-[10px] border-2 border-secondary font-extrabold bg-white">
+        <img
+          src={dragIcon}
+          className="size-10 cursor-grab active:cursor-grabbing"
+          draggable={false}
+          {...attributes}
+          {...listeners}
+        />
+        <span className="shrink-0 text-2xl text-primary">{index}</span>
+        <p className="font-extrabold">{content}</p>
+        <div className="ml-auto flex items-center gap-2">
+          <p className="text-lg text-primary">{hour}시간</p>
+          <img src={editIcon} className="size-6 cursor-pointer" />
+          <img src={deleteIcon} className="size-6 cursor-pointer" />
+        </div>
+      </article>
+    </li>
+  );
+}
+
+export default PlanItem;

--- a/src/pages/DashBoard/components/PlanItemOverlay.tsx
+++ b/src/pages/DashBoard/components/PlanItemOverlay.tsx
@@ -1,0 +1,26 @@
+import dragIcon from "@/assets/icons/drag_indicator_icon.png";
+import deleteIcon from "@/assets/icons/delete_icon.png";
+import editIcon from "@/assets/icons/edit_icon.png";
+
+interface Props {
+  index: number;
+  content: string;
+  hour: number;
+}
+
+function PlanItemOverlay({ index, content, hour }: Props) {
+  return (
+    <div className="h-[60px] pr-2 flex items-center gap-2 rounded-[10px] border-2 border-secondary font-extrabold bg-white shadow-lg">
+      <img src={dragIcon} className="size-10" />
+      <span className="shrink-0 text-2xl text-primary">{index}</span>
+      <p className="font-extrabold">{content}</p>
+      <div className="ml-auto flex items-center gap-2">
+        <p className="text-lg text-primary">{hour}시간</p>
+        <img src={editIcon} className="size-6" />
+        <img src={deleteIcon} className="size-6" />
+      </div>
+    </div>
+  );
+}
+
+export default PlanItemOverlay;

--- a/src/pages/DashBoard/components/PlanList.tsx
+++ b/src/pages/DashBoard/components/PlanList.tsx
@@ -1,7 +1,8 @@
-import dragIcon from '@/assets/icons/drag_indicator_icon.png'
-import deleteIcon from '@/assets/icons/delete_icon.png'
-import editIcon from '@/assets/icons/edit_icon.png'
-
+import { DndContext, closestCenter, DragOverlay } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { useSortableList } from "../hooks/useSortableList";
+import PlanItem from "./PlanItem";
+import PlanItemOverlay from "./PlanItemOverlay";
 
 const planItems = [
   { index: 1, content: "수영하기", hour: 3 },
@@ -26,38 +27,44 @@ const planItems = [
   { index: 20, content: "사진·영상 정리 및 회고", hour: 2 },
 ];
 
-
 function PlanList() {
+  const { items, activeId, sensors, handleDragStart, handleDragEnd, handleDragCancel } =
+    useSortableList(planItems.map((item) => String(item.index)));
+
+  const activePlan = activeId ? planItems.find((p) => String(p.index) === activeId) : null;
+
   return (
-    <ul className="flex flex-col gap-2 h-[350px] overflow-auto -mr-4" role="list">
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+    >
+      <ul className="flex flex-col gap-2 h-[350px] overflow-auto" role="list">
+        <SortableContext items={items} strategy={verticalListSortingStrategy}>
+          {items.map((id) => {
+            const plan = planItems.find((p) => String(p.index) === id);
+            if (!plan) return null;
+            return <PlanItem key={plan.index} {...plan} />;
+          })}
+        </SortableContext>
 
-          {
-            planItems.map(({ index, content, hour }) => (
-              <li key={index}>
-                <article className="h-[60px] pr-2 flex items-center gap-2 rounded-[10px] border-2 border-secondary font-extrabold">
-                  <img src={dragIcon} className='size-10 cursor-pointer' />
-                  <span className="shrink-0 text-2xl text-primary">{index}</span>
-                  <p className="font-extrabold">{content}</p>
+        <li>
+          <button
+            type="button"
+            className="h-[60px] flex w-full items-center justify-center rounded-[10px] bg-secondary font-extrabold text-white hover:brightness-95 active:brightness-90"
+          >
+            + 커스텀 일정 추가하기
+          </button>
+        </li>
+      </ul>
 
-                  <div className="ml-auto flex items-center gap-2">
-                    <p className='text-lg text-primary'>{hour}시간</p>
-                    <img src={editIcon} className='size-6 cursor-pointer'/>
-                    <img src={deleteIcon} className='size-6 cursor-pointer' />
-                  </div>
-                </article>
-              </li>
-            ))
-          }
-
-          <li>
-            <button
-              type="button"
-              className="h-[60px] flex w-full items-center justify-center rounded-[10px] bg-secondary font-extrabold text-white hover:brightness-95 active:brightness-90"
-            >
-              + 커스텀 일정 추가하기
-            </button>
-          </li>
-        </ul>
-  )
+      <DragOverlay>
+        {activePlan ? <PlanItemOverlay {...activePlan} /> : null}
+      </DragOverlay>
+    </DndContext>
+  );
 }
-export default PlanList
+
+export default PlanList;

--- a/src/pages/DashBoard/hooks/useSortableList.ts
+++ b/src/pages/DashBoard/hooks/useSortableList.ts
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import {
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragStartEvent,
+  type DragEndEvent,
+  type UniqueIdentifier,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
+
+export function useSortableList(initialItems: string[]) {
+  const [items, setItems] = useState(initialItems);
+  const [activeId, setActiveId] = useState<UniqueIdentifier | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  function handleDragStart(event: DragStartEvent) {
+    setActiveId(event.active.id);
+  }
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+
+    if (over && active.id !== over.id) {
+      setItems((prev) => {
+        const oldIndex = prev.indexOf(active.id as string);
+        const newIndex = prev.indexOf(over.id as string);
+        return arrayMove(prev, oldIndex, newIndex);
+      });
+    }
+
+    setActiveId(null);
+  }
+
+  function handleDragCancel() {
+    setActiveId(null);
+  }
+
+  return {
+    items,
+    activeId,
+    sensors,
+    handleDragStart,
+    handleDragEnd,
+    handleDragCancel,
+  };
+}


### PR DESCRIPTION
## 🌟 작업 개요
- 드래드 앤 드랍 기능 추가

## 📝 작업 내용
- dnd-kit 라이브러리를 활용하여 일정 리스트에 dnd 기능을 추가하였습니다.

## ‼️ 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #4 