### PR TITLE
[feat] 대시보드 웹소켓 공동 편집 구현 (#8)

### DIFF
--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -15,6 +15,7 @@ import { useProfileStore } from "@/store/profileStore";
 import { useState } from "react";
 import GroupMemberList from "@/pages/Group/components/GroupMemberList";
 import { useGroupMembers } from "@/pages/Group/hooks/useGroupMembers";
+import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore";
 
 const link = ({ isActive }: { isActive: boolean }) =>
   [
@@ -33,7 +34,10 @@ export default function Sidebar() {
 
   const {profile} = useProfileStore();
   const currentGroup = useGroupStore((s) => s.currentGroup);
-  const { members, onlineUserIds, loading } = useGroupMembers(currentGroup?.id);
+   // 그룹 멤버 (DB에서 불러오기)
+  const { members, loading } = useGroupMembers(currentGroup?.id);
+  // Presence (온라인 목록)
+  const onlineUserIds = usePresenceStore((s) => s.onlineUserIds);
 
 
   const {userId} = useParams<{userId:string}>();

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -13,6 +13,8 @@ import useCurrentGroup from "@/pages/Group/hooks/useCurrentGroup";
 import useCurrentProfile from "@/pages/Group/hooks/useCurrentProfile";
 import { useProfileStore } from "@/store/profileStore";
 import { useState } from "react";
+import GroupMemberList from "@/pages/Group/components/GroupMemberList";
+import { useGroupMembers } from "@/pages/Group/hooks/useGroupMembers";
 
 const link = ({ isActive }: { isActive: boolean }) =>
   [
@@ -31,6 +33,7 @@ export default function Sidebar() {
 
   const {profile} = useProfileStore();
   const currentGroup = useGroupStore((s) => s.currentGroup);
+  const { members, onlineUserIds, loading } = useGroupMembers(currentGroup?.id);
 
 
   const {userId} = useParams<{userId:string}>();
@@ -103,6 +106,19 @@ export default function Sidebar() {
           </>
         )}
       </nav>
+
+      <hr className="my-4 border-slate-200" />
+
+      {currentGroup && (
+        <div>
+          <h3 className="mb-3 font-bold">그룹 멤버</h3>
+          {loading ? (
+            <p className="text-gray-400 text-sm">불러오는 중...</p>
+          ) : (
+            <GroupMemberList members={members} onlineUserIds={onlineUserIds} />
+          )}
+        </div>
+      )}
 
       <div className="flex-1" />
 

--- a/src/pages/DashBoard/api/getMyProfile.ts
+++ b/src/pages/DashBoard/api/getMyProfile.ts
@@ -1,0 +1,33 @@
+import { supabase } from "@/lib/supabaseClient";
+
+export type MyProfile = {
+  id: string;
+  email: string;
+  name: string;
+  avatar_url: string | null;
+};
+
+export async function getMyProfile(): Promise<MyProfile | null> {
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser();
+
+  if (authError || !user) {
+    console.error("❌ 유저 인증 정보 없음:", authError?.message);
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from("profile")
+    .select("id, email, name, avatar_url")
+    .eq("id", user.id)
+    .single();
+
+  if (error) {
+    console.error("❌ 프로필 가져오기 실패:", error.message);
+    return null;
+  }
+
+  return data;
+}

--- a/src/pages/DashBoard/api/getMyUserId.ts
+++ b/src/pages/DashBoard/api/getMyUserId.ts
@@ -1,0 +1,15 @@
+import { supabase } from "@/lib/supabaseClient";
+
+export async function getMyUserId(): Promise<string | null> {
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error) {
+    console.error("❌ 유저 ID 가져오기 실패:", error.message);
+    return null;
+  }
+
+  return user?.id ?? null;
+}

--- a/src/pages/DashBoard/api/loadGroupData.ts
+++ b/src/pages/DashBoard/api/loadGroupData.ts
@@ -1,12 +1,7 @@
 import {supabase} from "@/lib/supabaseClient"
+import type { Database } from "@/types/supabase";
 
-export interface Group {
-id: string;
-name: string;
-owner_id: string;
-start_day: string; // 'YYYY-MM-DD' format
-end_day: string;   // 'YYYY-MM-DD' format
-}
+export type Group = Database["public"]["Tables"]["groups"]["Row"];
 
 export async function loadGroupData(groupId: string): Promise<Group | null> {
  const { data, error } = await supabase

--- a/src/pages/DashBoard/components/PlanItem.tsx
+++ b/src/pages/DashBoard/components/PlanItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import dragIcon from "@/assets/icons/drag_indicator_icon.png";
@@ -42,8 +42,23 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
   const [tempTitle, setTempTitle] = useState(title);
   const [tempDuration, setTempDuration] = useState(duration);
 
+  useEffect(() => {
+    setTempTitle(title);
+    setTempDuration(duration);
+  }, [title, duration]);
+
+  const handleCancel = () => {
+    // 원래 값으로 초기화
+    setTempTitle(title);
+    setTempDuration(duration);
+    // 편집 상태 제거
+    removeEditingItem(id);
+  };
+
   const hours = Math.floor(duration / 60);
   const minutes = duration % 60;
+
+
 
   return (
     <li ref={setNodeRef} style={style}>
@@ -92,7 +107,7 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
             />
             <button
               className="text-xs text-red-500 ml-2"
-              onClick={() => removeEditingItem(id)}
+              onClick={handleCancel}
             >
               취소
             </button>

--- a/src/pages/DashBoard/components/PlanItem.tsx
+++ b/src/pages/DashBoard/components/PlanItem.tsx
@@ -1,49 +1,59 @@
-import { useState } from "react"
-import { useSortable } from "@dnd-kit/sortable"
-import { CSS } from "@dnd-kit/utilities"
-import dragIcon from "@/assets/icons/drag_indicator_icon.png"
-import deleteIcon from "@/assets/icons/delete_icon.png"
-import editIcon from "@/assets/icons/edit_icon.png"
-import confirmIcon from "@/assets/icons/confirm_icon.png"
-import { usePlanStore } from "../store/planStore"
+import { useState } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import dragIcon from "@/assets/icons/drag_indicator_icon.png";
+import deleteIcon from "@/assets/icons/delete_icon.png";
+import editIcon from "@/assets/icons/edit_icon.png";
+import confirmIcon from "@/assets/icons/confirm_icon.png";
+import { usePlanStore } from "../store/planStore";
+import { usePresenceStore } from "../store/presenceStore";
 
 interface Props {
-  id: string
-  title: string
-  duration: number
-  address: string | null
-  sort_order: string
-  displayIndex: number
+  id: string;
+  title: string;
+  duration: number;
+  address: string | null;
+  sort_order: string;
+  displayIndex: number;
 }
 
 function PlanItem({ id, title, duration, displayIndex }: Props) {
   const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id })
+    useSortable({ id });
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
-  }
+  };
 
-  const deletePlan = usePlanStore((s) => s.deletePlanItem)
-  const editingItemIds = usePlanStore((s) => s.editingItemIds)
-  const addEditingItem = usePlanStore((s) => s.addEditingItem)
-  const removeEditingItem = usePlanStore((s) => s.removeEditingItem)
-  const confirmEditItem = usePlanStore((s) => s.confirmEditItem)
+  const deletePlan = usePlanStore((s) => s.deletePlanItem);
+  const editingItemIds = usePlanStore((s) => s.editingItemIds);
+  const addEditingItem = usePlanStore((s) => s.addEditingItem);
+  const removeEditingItem = usePlanStore((s) => s.removeEditingItem);
+  const confirmEditItem = usePlanStore((s) => s.confirmEditItem);
 
-  const isEditing = editingItemIds.includes(id)
+  const myProfile = usePresenceStore((s) => s.myProfile);
 
-  const [tempTitle, setTempTitle] = useState(title)
-  const [tempDuration, setTempDuration] = useState(duration)
+  // ✅ 현재 아이템 수정자 찾기
+  const editor = editingItemIds.find((e) => e.itemId === id);
+  const isEditingByMe = editor?.userId === myProfile?.id;
+  const isEditingByOther = editor && editor.userId !== myProfile?.id;
 
-  const hours = Math.floor(duration / 60)
-  const minutes = duration % 60
+  const [tempTitle, setTempTitle] = useState(title);
+  const [tempDuration, setTempDuration] = useState(duration);
+
+  const hours = Math.floor(duration / 60);
+  const minutes = duration % 60;
 
   return (
     <li ref={setNodeRef} style={style}>
       <article
         className={`h-[60px] pr-2 flex items-center gap-2 rounded-[10px] border-2 font-extrabold ${
-          isEditing ? "bg-gray-200 opacity-80 border-gray-400" : "bg-white border-secondary"
+          isEditingByMe
+            ? "bg-gray-200 opacity-80 border-gray-400"
+            : isEditingByOther
+              ? "bg-gray-100 opacity-60 border-gray-300"
+              : "bg-white border-secondary"
         }`}
       >
         <img
@@ -56,7 +66,8 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
 
         <span className="shrink-0 text-2xl text-primary">{displayIndex}</span>
 
-        {isEditing ? (
+        {isEditingByMe ? (
+          // ✅ 내가 수정 중일 때
           <>
             <input
               className="border px-2 py-1 rounded text-sm"
@@ -86,7 +97,13 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
               취소
             </button>
           </>
+        ) : isEditingByOther ? (
+          // ✅ 다른 사람이 수정 중일 때
+          <p className="text-sm text-red-500 ml-4">
+            지금 {editor.userName}님이 수정 중...
+          </p>
         ) : (
+          // ✅ 아무도 수정 안 할 때
           <>
             <p className="font-extrabold">{title}</p>
             <div className="ml-auto flex items-center gap-2">
@@ -97,8 +114,19 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
               </p>
               <img
                 src={editIcon}
-                className="size-6 cursor-pointer"
-                onClick={() => addEditingItem(id)}
+                className={`size-6 cursor-pointer ${
+                  editingItemIds.some((e) => e.userId === myProfile?.id)
+                    ? "opacity-50 cursor-not-allowed"
+                    : ""
+                }`}
+                onClick={() => {
+                  // 내가 이미 다른 아이템을 수정 중이면 막기
+                  if (editingItemIds.some((e) => e.userId === myProfile?.id)) {
+                    alert("이미 다른 아이템을 수정 중입니다.");
+                    return;
+                  }
+                  addEditingItem(id);
+                }}
               />
               <img
                 src={deleteIcon}
@@ -110,7 +138,7 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
         )}
       </article>
     </li>
-  )
+  );
 }
 
-export default PlanItem
+export default PlanItem;

--- a/src/pages/DashBoard/index.tsx
+++ b/src/pages/DashBoard/index.tsx
@@ -17,6 +17,8 @@ function DashBoard() {
   useEffect(() => {
     if (!group) return;
 
+    usePlanStore.getState().clearEditingItems();
+
     const myProfile = usePresenceStore.getState().myProfile;
     const myUserId = myProfile?.id ?? "guest";
 
@@ -98,6 +100,22 @@ function DashBoard() {
     });
 
     return () => {
+      const myProfile = usePresenceStore.getState().myProfile;
+      const editingItems = usePlanStore.getState().editingItemIds;
+      
+      if (myProfile && editingItems.length > 0) {
+        editingItems.forEach((item) => {
+          if (item.userId === myProfile.id) {
+            channel.send({
+              type: "broadcast",
+              event: "edit-end",
+              payload: { itemId: item.itemId, userId: myProfile.id },
+            });
+          }
+        });
+      }
+      
+      usePlanStore.getState().clearEditingItems();
       supabase.removeChannel(channel);
     };
   }, [group, navigate]);

--- a/src/pages/DashBoard/index.tsx
+++ b/src/pages/DashBoard/index.tsx
@@ -1,13 +1,83 @@
-import Map from "@/pages/DashBoard/components/Map"
-import Schedule from "@/pages/DashBoard/components/Schedule"
+import { useEffect } from "react";
+import Map from "@/pages/DashBoard/components/Map";
+import Schedule from "@/pages/DashBoard/components/Schedule";
+import { supabase } from "@/lib/supabaseClient";
+import { useGroupStore } from "./store/groupStore";
+import { usePlanStore } from "./store/planStore";
+import { useNavigate } from "react-router";
+import type { Group } from "./api/loadGroupData";
+import type { PlanItem } from "./api/loadPlanItem";
 
 function DashBoard() {
+  const group = useGroupStore((state) => state.group); // 참가하고자 하는 그룹을 가져옴.
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!group) return;
+    console.log(group);
+    const channel = supabase
+      .channel(group.id)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "groups",
+        },
+        (payload) => {
+          switch (payload.eventType) {
+            case "UPDATE":
+              useGroupStore.getState().setGroup(payload.new as Group);
+              break;
+            case "DELETE":
+              navigate("/", { replace: true });
+              break;
+            case "INSERT":
+            default:
+              return null;
+          }
+        },
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "planitems",
+        },
+        (payload) => {
+          console.log("🔔 DB 변경 감지:", payload);
+
+          switch (payload.eventType) {
+            case "INSERT":
+              usePlanStore.getState().addPlanItem(payload.new as PlanItem);
+              break;
+            case "UPDATE":
+              usePlanStore
+                .getState()
+                .updatePlanItem(payload.new.id, payload.new as PlanItem);
+              break;
+            case "DELETE":
+              usePlanStore.getState().removePlanItem(payload.old.id);
+              break;
+          }
+        },
+      )
+      .subscribe((status) => {
+        console.log("채널 상태:", status); // SUBSCRIBED 되어야 정상
+      });
+
+    return () => {
+      // 페이지 언마운트 되면 클린업.
+      supabase.removeChannel(channel);
+    };
+  }, [group, navigate]);
+
   return (
-    // 컨테이너
     <div className="bg-[#FAFAFA] w-full h-full border-2 border-black flex flex-row">
       <Schedule />
       <Map />
     </div>
-  )
+  );
 }
-export default DashBoard
+export default DashBoard;

--- a/src/pages/DashBoard/store/presenceStore.ts
+++ b/src/pages/DashBoard/store/presenceStore.ts
@@ -1,0 +1,16 @@
+// src/store/presenceStore.ts
+import { create } from "zustand";
+
+type PresenceState = {
+  myUserId: string | null;
+  onlineUserIds: string[];
+  setMyUserId: (id: string | null) => void;
+  setOnlineUserIds: (ids: string[]) => void;
+};
+
+export const usePresenceStore = create<PresenceState>((set) => ({
+  myUserId: null,
+  onlineUserIds: [],
+  setMyUserId: (id) => set({ myUserId: id }),
+  setOnlineUserIds: (ids) => set({ onlineUserIds: ids }),
+}));

--- a/src/pages/DashBoard/store/presenceStore.ts
+++ b/src/pages/DashBoard/store/presenceStore.ts
@@ -1,16 +1,18 @@
-// src/store/presenceStore.ts
+
 import { create } from "zustand";
+import type { MyProfile } from "../api/getMyProfile";
+
 
 type PresenceState = {
-  myUserId: string | null;
+  myProfile: MyProfile | null;  
   onlineUserIds: string[];
-  setMyUserId: (id: string | null) => void;
+  setMyProfile: (p: MyProfile | null) => void;
   setOnlineUserIds: (ids: string[]) => void;
 };
 
 export const usePresenceStore = create<PresenceState>((set) => ({
-  myUserId: null,
+  myProfile: null,
   onlineUserIds: [],
-  setMyUserId: (id) => set({ myUserId: id }),
+  setMyProfile: (p) => set({ myProfile: p }),
   setOnlineUserIds: (ids) => set({ onlineUserIds: ids }),
 }));

--- a/src/pages/Group/api/getGroupMembers.ts
+++ b/src/pages/Group/api/getGroupMembers.ts
@@ -1,0 +1,15 @@
+import { supabase } from "@/lib/supabaseClient";
+
+export async function getGroupMembers(groupId: string) {
+  const { data, error } = await supabase
+    .from("group_members_with_profile")
+    .select("user_id, name, avatar_url, role, created_at")
+    .eq("group_id", groupId);
+
+  if (error) {
+    console.error("Error fetching group members:", error.message);
+    throw error;
+  }
+
+  return data;
+}

--- a/src/pages/Group/components/GroupMemberList.tsx
+++ b/src/pages/Group/components/GroupMemberList.tsx
@@ -1,0 +1,38 @@
+import defaultProfile from "@/assets/defaultprofile.svg";
+import { GoDotFill } from "react-icons/go";
+import { getColorForUser } from "../utils/colorUtils";
+
+type Props = {
+  members: {
+    user_id: string;
+    name: string;
+    avatar_url: string | null;
+  }[];
+  onlineUserIds: string[];
+};
+
+export default function GroupMemberList({ members, onlineUserIds }: Props) {
+  return (
+    <ul className="flex flex-col gap-4">
+      {members.map((m) => {
+        const isOnline = onlineUserIds.includes(m.user_id);
+        const dotColor = getColorForUser(m.user_id);
+
+        return (
+          <li key={m.user_id} className="flex gap-3 items-center">
+            <img
+              className="size-8 rounded-full"
+              src={m.avatar_url ?? defaultProfile}
+              alt={`${m.name} 프로필 이미지`}
+              onError={(e) =>
+                ((e.currentTarget as HTMLImageElement).src = defaultProfile)
+              }
+            />
+            <p>{m.name}</p>
+            {isOnline && <GoDotFill className={`size-5 ${dotColor}`} />}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/pages/Group/components/GroupMemberList.tsx
+++ b/src/pages/Group/components/GroupMemberList.tsx
@@ -2,16 +2,22 @@ import defaultProfile from "@/assets/defaultprofile.svg";
 import { GoDotFill } from "react-icons/go";
 import { getColorForUser } from "../utils/colorUtils";
 
-type Props = {
-  members: {
-    user_id: string;
-    name: string;
-    avatar_url: string | null;
-  }[];
+export type GroupMember = {
+  user_id: string;
+  name: string;
+  avatar_url: string | null;
+};
+
+interface Props  {
+  members: GroupMember[];
   onlineUserIds: string[];
 };
 
 export default function GroupMemberList({ members, onlineUserIds }: Props) {
+  if (members.length === 0) {
+    return <p className="text-gray-400 text-sm">멤버가 없습니다.</p>;
+  }
+
   return (
     <ul className="flex flex-col gap-4">
       {members.map((m) => {
@@ -24,11 +30,11 @@ export default function GroupMemberList({ members, onlineUserIds }: Props) {
               className="size-8 rounded-full"
               src={m.avatar_url ?? defaultProfile}
               alt={`${m.name} 프로필 이미지`}
-              onError={(e) =>
-                ((e.currentTarget as HTMLImageElement).src = defaultProfile)
-              }
+              onError={(e) => {
+                (e.currentTarget as HTMLImageElement).src = defaultProfile;
+              }}
             />
-            <p>{m.name}</p>
+            <p className="text-sm font-medium">{m.name}</p>
             {isOnline && <GoDotFill className={`size-5 ${dotColor}`} />}
           </li>
         );

--- a/src/pages/Group/hooks/useGroupMembers.ts
+++ b/src/pages/Group/hooks/useGroupMembers.ts
@@ -11,7 +11,6 @@ type GroupMember = {
 
 export function useGroupMembers(groupId: string | undefined) {
   const [members, setMembers] = useState<GroupMember[]>([]);
-  const [onlineUserIds, setOnlineUserIds] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -20,14 +19,10 @@ export function useGroupMembers(groupId: string | undefined) {
 
     getGroupMembers(groupId)
       .then((data) => {
-        if (data) setMembers(data as GroupMember[]); 
+        if (data) setMembers(data as GroupMember[]);
       })
       .finally(() => setLoading(false));
   }, [groupId]);
 
-  // TODO: Presence 구독 추가 예정
-  // 예: supabase.channel(`group:${groupId}`).on("presence", ...)
-  // 여기서 setOnlineUserIds([...]) 업데이트
-
-  return { members, onlineUserIds, loading };
+  return { members, loading };
 }

--- a/src/pages/Group/hooks/useGroupMembers.ts
+++ b/src/pages/Group/hooks/useGroupMembers.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { getGroupMembers } from "@/pages/Group/api/getGroupMembers";
+
+type GroupMember = {
+  user_id: string;
+  name: string;
+  avatar_url: string | null;
+  role: "admin" | "member";
+  created_at: string;
+};
+
+export function useGroupMembers(groupId: string | undefined) {
+  const [members, setMembers] = useState<GroupMember[]>([]);
+  const [onlineUserIds, setOnlineUserIds] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!groupId) return;
+    setLoading(true);
+
+    getGroupMembers(groupId)
+      .then((data) => {
+        if (data) setMembers(data as GroupMember[]); 
+      })
+      .finally(() => setLoading(false));
+  }, [groupId]);
+
+  // TODO: Presence 구독 추가 예정
+  // 예: supabase.channel(`group:${groupId}`).on("presence", ...)
+  // 여기서 setOnlineUserIds([...]) 업데이트
+
+  return { members, onlineUserIds, loading };
+}

--- a/src/pages/Group/utils/colorUtils.ts
+++ b/src/pages/Group/utils/colorUtils.ts
@@ -1,0 +1,17 @@
+const COLORS = [
+  "text-green-500",
+  "text-blue-500",
+  "text-red-500",
+  "text-yellow-500",
+  "text-purple-500",
+  "text-pink-500",
+  "text-indigo-500",
+];
+
+export function getColorForUser(userId: string): string {
+  let hash = 0;
+  for (let i = 0; i < userId.length; i++) {
+    hash = userId.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return COLORS[Math.abs(hash) % COLORS.length];
+}

--- a/src/pages/Group/utils/colorUtils.ts
+++ b/src/pages/Group/utils/colorUtils.ts
@@ -1,11 +1,14 @@
 const COLORS = [
-  "text-green-500",
-  "text-blue-500",
-  "text-red-500",
-  "text-yellow-500",
-  "text-purple-500",
-  "text-pink-500",
-  "text-indigo-500",
+  "text-pink-300",
+  "text-blue-300",
+  "text-green-300",
+  "text-yellow-300",
+  "text-purple-300",
+  "text-indigo-300",
+  "text-red-300",
+  "text-teal-300",
+  "text-orange-300",
+  "text-cyan-300",
 ];
 
 export function getColorForUser(userId: string): string {

--- a/src/router/loader/dashBoardLoader.ts
+++ b/src/router/loader/dashBoardLoader.ts
@@ -5,6 +5,8 @@ import { loadPlanItems, type PlanItem } from "@/pages/DashBoard/api/loadPlanItem
 import { useGroupStore } from "@/pages/DashBoard/store/groupStore"
 import { generateTripDays } from "@/pages/DashBoard/utils/generateTripDays"
 import { usePlanStore } from "@/pages/DashBoard/store/planStore"
+import { getMyUserId } from "@/pages/DashBoard/api/getMyUserId"
+import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore"
 
 
 export type DashboardLoaderData = {
@@ -32,6 +34,9 @@ export async function dashboardLoader(
   usePlanStore.getState().setTripDays(tripDays)
   usePlanStore.getState().setSelectedDay(groupData.start_day)
   usePlanStore.getState().setAllPlanItems(allPlanItems || [])
+
+  const myId = await getMyUserId()
+  usePresenceStore.getState().setMyUserId(myId)
 
   return null;
 }

--- a/src/router/loader/dashBoardLoader.ts
+++ b/src/router/loader/dashBoardLoader.ts
@@ -5,9 +5,8 @@ import { loadPlanItems, type PlanItem } from "@/pages/DashBoard/api/loadPlanItem
 import { useGroupStore } from "@/pages/DashBoard/store/groupStore"
 import { generateTripDays } from "@/pages/DashBoard/utils/generateTripDays"
 import { usePlanStore } from "@/pages/DashBoard/store/planStore"
-import { getMyUserId } from "@/pages/DashBoard/api/getMyUserId"
+import { getMyProfile } from "@/pages/DashBoard/api/getMyProfile" 
 import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore"
-
 
 export type DashboardLoaderData = {
   groupData: Group
@@ -35,8 +34,8 @@ export async function dashboardLoader(
   usePlanStore.getState().setSelectedDay(groupData.start_day)
   usePlanStore.getState().setAllPlanItems(allPlanItems || [])
 
-  const myId = await getMyUserId()
-  usePresenceStore.getState().setMyUserId(myId)
+  const myProfile = await getMyProfile()
+  usePresenceStore.getState().setMyProfile(myProfile)
 
-  return null;
+  return null
 }

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -7,7 +7,8 @@
   | Json[]
 
 export type Database = {
-
+  // Allows to automatically instantiate createClient with right options
+  // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
     PostgrestVersion: "13.0.4"
   }
@@ -195,7 +196,7 @@ export type Database = {
           duration: number
           group_id: string
           id: string
-          jitter: string 
+          jitter: string | null
           latitude: number | null
           longitude: number | null
           sort_order: string
@@ -207,7 +208,7 @@ export type Database = {
           duration?: number
           group_id: string
           id?: string
-          jitter?: string 
+          jitter?: string | null
           latitude?: number | null
           longitude?: number | null
           sort_order: string
@@ -219,7 +220,7 @@ export type Database = {
           duration?: number
           group_id?: string
           id?: string
-          jitter?: string 
+          jitter?: string | null
           latitude?: number | null
           longitude?: number | null
           sort_order?: string
@@ -258,7 +259,32 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      group_members_with_profile: {
+        Row: {
+          avatar_url: string | null
+          created_at: string | null
+          group_id: string | null
+          name: string | null
+          role: Database["public"]["Enums"]["member_role"] | null
+          user_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "groupmembers_group_id_fkey"
+            columns: ["group_id"]
+            isOneToOne: false
+            referencedRelation: "groups"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "groupmembers_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profile"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
     }
     Functions: {
       same_group: {


### PR DESCRIPTION
## 🌟 작업 개요
- 이제 그룹 입장시 그룹 멤버 목록을 확인 할 수 있습니다.
- 현재 접속한 멤버를 확인 할 수 있습니다.
- 특정 멤버가 일정을 수정할때 다른 멤버에게도 수정중 상태가 공유됩니다.
- 수정 중인 상태에서 그룹을 벗어나면 수정 상태가 취소됩니다.

## 📝 작업 내용
- presenceStore 스토어를 추가하였습니다.
: 현재 접속자 상태를 관리하기 위함.

- supabase에 group_members_with_profile 뷰를 만들었습니다.
: 통신 로직의 가독성을 높이기 위해서.

- sidebar 에 그룹에 참여하는 모든 멤버의 목록을 출력하도록 만들었습니다.

<img width="1228" height="921" alt="스샷" src="https://github.com/user-attachments/assets/6ec96464-6e92-4388-b338-a9a833505202" />


## ‼️ 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #8 