### PR TITLE
[fix] : 그룹 단위의 presence 구현 (#90)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7065,6 +7065,16 @@
         "react": ">=16.0.0"
       }
     },
+    "node_modules/proc-log": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-5.0.0.tgz",
+      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/processenv": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/processenv/-/processenv-1.1.0.tgz",
@@ -7267,6 +7277,16 @@
       "peerDependencies": {
         "react": ">=16 || >=17 || >= 18 || >= 19",
         "react-dom": ">=16 || >=17 || >= 18 || >=19"
+      }
+    },
+    "node_modules/read-cmd-shim": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/read-cmd-shim/-/read-cmd-shim-5.0.0.tgz",
+      "integrity": "sha512-SEbJV7tohp3DAAILbEMPXavBjAnMN0tVnh4+9G8ihV4Pq3HYF9h8QNez9zkJ1ILkv9G2BjdzwctznGZXgu/HGw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/readable-stream": {

--- a/src/pages/Group/components/GroupLayout.tsx
+++ b/src/pages/Group/components/GroupLayout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from "react-router-dom";
+import GroupPresenceProvider from "./GroupPresenceProvider";
+
+export default function GroupLayout() {
+  return (
+    <GroupPresenceProvider>
+      <Outlet />
+    </GroupPresenceProvider>
+  );
+}
+

--- a/src/pages/Group/components/GroupPresenceProvider.tsx
+++ b/src/pages/Group/components/GroupPresenceProvider.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import { useParams } from "react-router";
+import { supabase } from "@/lib/supabaseClient";
+import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore";
+
+type Props = {
+  children: React.ReactNode;
+};
+
+
+export default function GroupPresenceProvider({ children }: Props) {
+  const { groupId } = useParams<{ groupId: string }>();
+
+  useEffect(() => {
+    if (!groupId) return;
+    let mounted = true;
+
+    let channel: ReturnType<typeof supabase.channel> | null = null;
+
+    async function setupPresenceChannel() {
+      const { data: sessionData } = await supabase.auth.getSession();
+      const userId = sessionData.session?.user?.id ?? "guest";
+
+      channel = supabase.channel(`presence_${groupId}`, {
+        config: { presence: { key: userId } },
+      });
+
+      // 서버에서 presence 목록 동기화 될 때마다 실행
+      channel.on("presence", { event: "sync" }, () => {
+        if (!mounted) return;
+        const state = channel!.presenceState() as Record<string, unknown>;
+        const onlineIds = Object.keys(state);
+        usePresenceStore.getState().setOnlineUserIds(onlineIds);
+      });
+
+      // 채널에 정상적으로 구독되면 내 presence 등록
+      channel.subscribe((status) => {
+        if (status === "SUBSCRIBED") {
+          channel?.track({ user_id: userId, online_at: new Date().toISOString() });
+        }
+      });
+    }
+
+    setupPresenceChannel();
+
+    // cleanup
+    return () => {
+      mounted = false;
+      if (channel) {
+        void channel.untrack();
+        supabase.removeChannel(channel);
+      }
+    };
+  }, [groupId]);
+
+  return <>{children}</>;
+}

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -3,6 +3,7 @@ import Album from "@/pages/Album";
 import AuthCallback from "@/pages/auth/AuthCallback";
 import Budget from "@/pages/BudgetPage";
 import GroupJoinPage from "@/pages/Group/pages/GroupJoinPage";
+import GroupLayout from "@/pages/Group/components/GroupLayout";
 import GroupsPage from "@/pages/Group/pages/GroupsPage";
 import { createBrowserRouter, Outlet, redirect, type LoaderFunctionArgs } from "react-router-dom";
 import HomeLayout from "../HomeLayout";
@@ -83,6 +84,7 @@ const router = createBrowserRouter([
           id: "group-layout",
           path:'g/:groupId',
           loader: loadGroup,
+          element: <GroupLayout />,
           children: [
             {index:true, element: <DashBoard />, loader: dashboardLoader},
             {path: "budget", element: <Budget />},


### PR DESCRIPTION
## 🌟 작업 개요
- 수파베이스 presence의 구독 시점을 그룹의 진입 점으로 바꿨습니다.
: 따라서 현재 접속 여부는 그룹 단위로 관리되며
: 예산, 앨범에서도 현재 접속 여부가 보입니다

- 기존 라우터의 구조를 보면 대시보드를 인덱스 페이지로 사용하고 있었고, 앨범과 예산, 대시보드를 묶어주는 부모 라우트가 없었습니다.
- GroupLayout 이라는 컴포넌트로 대시보드, 예산, 앨범을 묶어주고 GroupPresenceProvider 라는 프로바이더를 만들어서 presence 처리를 그룹단위에서 할 수 있도록 수정했습니다.

## 📝 작업 내용
<!-- 어떤 작업을 하였는지 체크박스 형식으로 적어주세요 -->

## ‼️ 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #