### PR TITLE
[feat] 수정 상태 동기화 문제 해결 (#108)

### DIFF
--- a/src/pages/DashBoard/components/PlanItem.tsx
+++ b/src/pages/DashBoard/components/PlanItem.tsx
@@ -80,9 +80,7 @@ function PlanItem({ id, title, duration, displayIndex }: Props) {
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseUp}
       onMouseLeave={handleMouseLeave}
-      className={`transition-transform duration-150 ease-out transform-gpu ${
-        isClickEffectActive ? "scale-95" : ""
-      }`}
+      className={`transition-transform duration-150 ease-out transform-gpu ${isClickEffectActive ? "scale-95" : ""} ${canApplyClickEffect ? "cursor-pointer" : "cursor-default"}`}
     >
       <article
         className={`h-[50px] pr-2 flex items-center gap-2 rounded-[10px] border-2 font-extrabold shadow-md ${

--- a/src/pages/DashBoard/components/TripDays.tsx
+++ b/src/pages/DashBoard/components/TripDays.tsx
@@ -1,3 +1,4 @@
+// TripDays.tsx
 import { useState, useEffect, useCallback } from "react";
 import { BsFillCaretLeftFill, BsFillCaretRightFill } from "react-icons/bs";
 import { usePlanStore } from "../store/planStore";
@@ -6,125 +7,124 @@ import { useGroupStore } from "../store/groupStore";
 import { supabase } from "@/lib/supabaseClient";
 
 function TripDays() {
-  const tripDaysData = usePlanStore((state) => state.tripDays);
-  const setSelectedDay = usePlanStore((state) => state.setSelectedDay);
-  const editingItemIds = usePlanStore((state) => state.editingItemIds);
-  const removeEditingItem = usePlanStore((state) => state.removeEditingItem);
-  
-  // 처음엔 인덱스 3(=4번째)을 중앙으로 시작
-  const [centerIndex, setCenterIndex] = useState(3);
+  // ─────────────────────────────
+  // Store 상태
+  const tripDays = usePlanStore((s) => s.tripDays);
+  const setSelectedDay = usePlanStore((s) => s.setSelectedDay);
+  const editingItemIds = usePlanStore((s) => s.editingItemIds);
+  const removeEditingItem = usePlanStore((s) => s.removeEditingItem);
 
-  // 항상 7일만 slice
-  const visibleDays = tripDaysData.slice(centerIndex - 3, centerIndex + 4);
+  // ─────────────────────────────
+  // 로컬 상태
+  const [centerIndex, setCenterIndex] = useState(3); // 처음 4번째(=인덱스 3)를 중앙으로
 
-  // tripDays가 바뀔 때 centerIndex 초기화
+  // 항상 7일만 보여줌
+  const visibleDays = tripDays.slice(centerIndex - 3, centerIndex + 4);
+
+  // tripDays가 바뀌면 중앙 초기화
   useEffect(() => {
     setCenterIndex(3);
-  }, [tripDaysData]);
+  }, [tripDays]);
 
-  // 선택된 날짜가 바뀔 때 수정 중인 아이템 정리
+  // ─────────────────────────────
+  // 수정 중인 아이템 정리
   const clearMyEditingItems = useCallback(() => {
     const myProfile = usePresenceStore.getState().myProfile;
     const group = useGroupStore.getState().group;
     if (!myProfile || !group) return;
 
-    const myEditingItems = editingItemIds.filter(item => item.userId === myProfile.id);
-    
-    if (myEditingItems.length > 0) {
-      // 각 수정 중인 아이템에 대해 브로드캐스트 전송
-      myEditingItems.forEach(item => {
-        supabase.channel(group.id).send({
-          type: "broadcast",
-          event: "edit-end",
-          payload: { itemId: item.itemId, userId: myProfile.id },
-        });
-        
-        // 로컬 상태에서 제거
-        removeEditingItem(item.itemId);
+    const myEditingItems = editingItemIds.filter(
+      (item) => item.userId === myProfile.id
+    );
+
+    myEditingItems.forEach((item) => {
+      // Broadcast
+      supabase.channel(group.id).send({
+        type: "broadcast",
+        event: "edit-end",
+        payload: { itemId: item.itemId, userId: myProfile.id },
       });
-    }
+
+      // 로컬 상태에서 제거
+      removeEditingItem(item.itemId);
+    });
   }, [editingItemIds, removeEditingItem]);
 
-  // 항상 가운데 날짜 선택
+  // 중앙 날짜가 바뀌면 선택 + 내 편집 아이템 해제
   useEffect(() => {
-    if (visibleDays[3]) {
-      // 날짜가 실제로 바뀔 때만 수정 중인 아이템 정리
-      const newSelectedDay = visibleDays[3].fullDate;
-      const currentSelectedDay = usePlanStore.getState().selectedDay;
-      
-      if (newSelectedDay !== currentSelectedDay) {
-        clearMyEditingItems();
-      }
-      
-      setSelectedDay(newSelectedDay);
+    if (!visibleDays[3]) return;
+
+    const newSelectedDay = visibleDays[3].fullDate;
+    const currentSelectedDay = usePlanStore.getState().selectedDay;
+
+    if (newSelectedDay !== currentSelectedDay) {
+      clearMyEditingItems();
     }
+    setSelectedDay(newSelectedDay);
   }, [visibleDays, setSelectedDay, clearMyEditingItems]);
 
+  // ─────────────────────────────
+  // 네비게이션
   const handlePrevious = () => {
-    if (centerIndex > 3) {
-      setCenterIndex((prev) => prev - 1);
-    }
+    if (centerIndex > 3) setCenterIndex((prev) => prev - 1);
   };
 
   const handleNext = () => {
-    if (centerIndex < tripDaysData.length - 4) {
-      setCenterIndex((prev) => prev + 1);
-    }
+    if (centerIndex < tripDays.length - 4) setCenterIndex((prev) => prev + 1);
   };
 
-  const handleDayClick = (clickedIndex: number) => {
-    // 가운데(인덱스 3)는 이미 선택된 상태이므로 무시
-    if (clickedIndex === 3) return;
-    
-    // 클릭한 날짜가 가운데로 오도록 centerIndex 조정
-    const targetCenterIndex = centerIndex + (clickedIndex - 3);
-    
-    // 범위 체크
-    if (targetCenterIndex >= 3 && targetCenterIndex <= tripDaysData.length - 4) {
+  const handleDayClick = (clickedIdx: number) => {
+    if (clickedIdx === 3) return; // 이미 중앙인 날짜는 무시
+    const targetCenterIndex = centerIndex + (clickedIdx - 3);
+
+    if (targetCenterIndex >= 3 && targetCenterIndex <= tripDays.length - 4) {
       setCenterIndex(targetCenterIndex);
     }
   };
 
-  // 실제 여행 기간인지 확인 (앞뒤 3개 제외)
-  const isTravelDay = (globalIndex: number) => {
-    return globalIndex >= 3 && globalIndex < tripDaysData.length - 3;
-  };
+  // 실제 여행일 판별 (앞뒤 3일 제외)
+  const isTravelDay = (globalIndex: number) =>
+    globalIndex >= 3 && globalIndex < tripDays.length - 3;
 
+  // ─────────────────────────────
+  // 렌더링
   return (
-    <div className="flex flex-row justify-between items-center w-full">
+    <div className="flex w-full flex-row items-center justify-between">
+      {/* 이전 버튼 */}
       <button
         type="button"
         onClick={handlePrevious}
         disabled={centerIndex <= 3}
         className={
           centerIndex <= 3
-            ? "text-gray-200 cursor-not-allowed"
-            : "text-primary cursor-pointer"
+            ? "cursor-not-allowed text-gray-200"
+            : "cursor-pointer text-primary"
         }
       >
         <BsFillCaretLeftFill className="size-8" />
       </button>
 
+      {/* 날짜 리스트 */}
       <div className="flex w-full max-w-3xl justify-between px-4">
         {visibleDays.map(({ dayOfTheWeek, date, fullDate }, idx) => {
           const isCenter = idx === 3;
-          const globalIndex = centerIndex - 3 + idx; // 전체 배열에서의 실제 인덱스
-          const isClickable = isTravelDay(globalIndex);
-          
+          const globalIndex = centerIndex - 3 + idx;
+          const clickable = isTravelDay(globalIndex);
+
           return (
             <div
               key={fullDate}
-              onClick={() => isClickable && handleDayClick(idx)}
-              className={`flex flex-col items-center justify-center pt-1 rounded-[20px] space-y-[-7px]
-                ${isCenter ? "bg-primary w-14" : "w-14"}
-                ${isClickable ? "cursor-pointer" : "cursor-not-allowed"}`}
+              onClick={() => clickable && handleDayClick(idx)}
+              className={`flex w-14 flex-col items-center justify-center space-y-[-7px] rounded-[20px] pt-1
+                ${isCenter ? "bg-primary" : ""}
+                ${clickable ? "cursor-pointer" : "cursor-not-allowed"}`}
             >
               <p
                 className={`text-1 font-bold select-none ${
-                  isCenter 
-                    ? "text-white" 
-                    : isClickable 
-                    ? "text-black" 
+                  isCenter
+                    ? "text-white"
+                    : clickable
+                    ? "text-black"
                     : "text-gray-400"
                 }`}
               >
@@ -132,10 +132,10 @@ function TripDays() {
               </p>
               <p
                 className={`text-3 font-bold select-none ${
-                  isCenter 
-                    ? "text-white" 
-                    : isClickable 
-                    ? "text-black" 
+                  isCenter
+                    ? "text-white"
+                    : clickable
+                    ? "text-black"
                     : "text-gray-200"
                 }`}
               >
@@ -146,14 +146,15 @@ function TripDays() {
         })}
       </div>
 
+      {/* 다음 버튼 */}
       <button
         type="button"
         onClick={handleNext}
-        disabled={centerIndex >= tripDaysData.length - 4}
+        disabled={centerIndex >= tripDays.length - 4}
         className={
-          centerIndex >= tripDaysData.length - 4
-            ? "text-gray-200 cursor-not-allowed"
-            : "text-primary cursor-pointer"
+          centerIndex >= tripDays.length - 4
+            ? "cursor-not-allowed text-gray-200"
+            : "cursor-pointer text-primary"
         }
       >
         <BsFillCaretRightFill className="size-8" />

--- a/src/pages/DashBoard/store/presenceStore.ts
+++ b/src/pages/DashBoard/store/presenceStore.ts
@@ -5,13 +5,17 @@ import type { MyProfile } from "../api/getMyProfile";
 type PresenceState = {
   myProfile: MyProfile | null;  
   onlineUserIds: string[];
+  onlineUsersById: Record<string, string>;
   setMyProfile: (p: MyProfile | null) => void;
   setOnlineUserIds: (ids: string[]) => void;
+  setOnlineUsersById: (map: Record<string, string>) => void;
 };
 
 export const usePresenceStore = create<PresenceState>((set) => ({
   myProfile: null,
   onlineUserIds: [],
+  onlineUsersById: {},
   setMyProfile: (p) => set({ myProfile: p }),
   setOnlineUserIds: (ids) => set({ onlineUserIds: ids }),
+  setOnlineUsersById: (map) => set({ onlineUsersById: map }),
 }));

--- a/src/pages/Group/components/GroupPresenceProvider.tsx
+++ b/src/pages/Group/components/GroupPresenceProvider.tsx
@@ -1,3 +1,4 @@
+// GroupPresenceProvider.tsx
 import { useEffect } from "react";
 import { useParams } from "react-router";
 import { supabase } from "@/lib/supabaseClient";
@@ -7,6 +8,11 @@ type Props = {
   children: React.ReactNode;
 };
 
+type PresenceMeta = {
+  user_id?: string;
+  user_name?: string;
+  online_at?: string;
+};
 
 export default function GroupPresenceProvider({ children }: Props) {
   const { groupId } = useParams<{ groupId: string }>();
@@ -15,7 +21,51 @@ export default function GroupPresenceProvider({ children }: Props) {
     if (!groupId) return;
     let mounted = true;
 
+    
     let channel: ReturnType<typeof supabase.channel> | null = null;
+
+    function handlePresenceSync() {
+      if (!mounted || !channel) return;
+
+      const state = channel.presenceState() as Record<string, PresenceMeta[]>;
+      const onlineIds = Object.keys(state);
+
+      // id → name 매핑 (가장 최근 메타 정보 우선)
+      const idNameMap: Record<string, string> = {};
+      for (const [id, metas] of Object.entries(state)) {
+        const meta = metas?.at(-1);
+        idNameMap[id] =
+          meta?.user_name?.trim()?.length ? meta.user_name : "알 수 없음";
+      }
+
+      const store = usePresenceStore.getState();
+      store.setOnlineUserIds(onlineIds);
+      store.setOnlineUsersById(idNameMap);
+    }
+
+    async function trackMyPresence(userId: string) {
+      let userName = usePresenceStore.getState().myProfile?.name ?? "";
+
+      // 프로필 이름이 비어 있으면 DB에서 한 번 조회
+      if (!userName && userId !== "guest") {
+        try {
+          const { data: profileRow } = await supabase
+            .from("profile")
+            .select("name")
+            .eq("id", userId)
+            .maybeSingle();
+          userName = profileRow?.name ?? "";
+        } catch {
+          // noop: 조회 실패 시 빈 문자열 유지
+        }
+      }
+
+      channel?.track({
+        user_id: userId,
+        user_name: userName,
+        online_at: new Date().toISOString(),
+      });
+    }
 
     async function setupPresenceChannel() {
       const { data: sessionData } = await supabase.auth.getSession();
@@ -25,63 +75,18 @@ export default function GroupPresenceProvider({ children }: Props) {
         config: { presence: { key: userId } },
       });
 
-      // 서버에서 presence 목록 동기화 될 때마다 실행
-      channel.on("presence", { event: "sync" }, () => {
-        if (!mounted) return;
+      // 서버에서 presence 목록 동기화
+      channel.on("presence", { event: "sync" }, handlePresenceSync);
 
-        // presenceState()의 형태는 { [userId]: Array<meta> }
-        type PresenceMeta = {
-          user_id?: string;
-          user_name?: string;
-          online_at?: string;
-        };
-        const state = channel!.presenceState() as Record<string, PresenceMeta[]>;
-
-        const onlineIds = Object.keys(state);
-
-        // id -> name 맵 생성 (가장 최근 메타 정보 우선)
-        const idNameMap: Record<string, string> = {};
-        for (const [id, metas] of Object.entries(state)) {
-          const meta = metas && metas.length > 0 ? metas[metas.length - 1] : undefined;
-          const userName = typeof meta?.user_name === "string" && meta.user_name.trim().length > 0
-            ? meta.user_name
-            : "알 수 없음";
-          idNameMap[id] = userName;
-        }
-
-        const store = usePresenceStore.getState();
-        store.setOnlineUserIds(onlineIds);
-        store.setOnlineUsersById(idNameMap);
-      });
-
-      // 채널에 정상적으로 구독되면 내 presence 등록
-      channel.subscribe(async (status) => {
+      // 채널 구독 후 내 presence 등록
+      channel.subscribe((status) => {
         if (status === "SUBSCRIBED") {
-          // 내 이름을 presence에 함께 실어 전송
-          let userName = usePresenceStore.getState().myProfile?.name ?? "";
-          if (!userName && userId && userId !== "guest") {
-            try {
-              const { data: profileRow } = await supabase
-                .from("profile")
-                .select("name")
-                .eq("id", userId)
-                .maybeSingle();
-              userName = profileRow?.name ?? "";
-            } catch {
-              // noop - 이름 없으면 빈 문자열 처리
-            }
-          }
-
-          channel?.track({
-            user_id: userId,
-            user_name: userName || "",
-            online_at: new Date().toISOString(),
-          });
+          void trackMyPresence(userId);
         }
       });
     }
 
-    setupPresenceChannel();
+    void setupPresenceChannel();
 
     // cleanup
     return () => {

--- a/src/router/loader/dashBoardLoader.ts
+++ b/src/router/loader/dashBoardLoader.ts
@@ -7,6 +7,7 @@ import { generateTripDays } from "@/pages/DashBoard/utils/generateTripDays"
 import { usePlanStore } from "@/pages/DashBoard/store/planStore"
 import { getMyProfile } from "@/pages/DashBoard/api/getMyProfile" 
 import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore"
+import { supabase } from "@/lib/supabaseClient"
 
 export type DashboardLoaderData = {
   groupData: Group
@@ -33,6 +34,44 @@ export async function dashboardLoader(
   usePlanStore.getState().setTripDays(tripDays)
   usePlanStore.getState().setSelectedDay(groupData.start_day)
   usePlanStore.getState().setAllPlanItems(allPlanItems || [])
+
+  // DB의 editing 컬럼을 사용해 편집 목록 덮어쓰기
+  if (allPlanItems && allPlanItems.length > 0) {
+    const editingPairs = allPlanItems
+      .filter((p) => p.editing !== null)
+      .map((p) => ({ itemId: p.id, userId: p.editing as string }));
+
+    if (editingPairs.length > 0) {
+      const presenceMap = usePresenceStore.getState().onlineUsersById;
+      const uniqueUserIds = Array.from(new Set(editingPairs.map((e) => e.userId)));
+
+      // presence에 이름이 없는 사용자만 프로필에서 조회
+      const missingIds = uniqueUserIds.filter((uid) => !presenceMap[uid] || presenceMap[uid].trim() === "");
+      let profileNameMap: Record<string, string> = {};
+      if (missingIds.length > 0) {
+        const { data } = await supabase
+          .from("profile")
+          .select("id, name")
+          .in("id", missingIds);
+        if (data) {
+          for (const row of data as Array<{ id: string; name: string }>) {
+            profileNameMap[row.id] = row.name;
+          }
+        }
+      }
+
+      const resolved = editingPairs.map(({ itemId, userId }) => {
+        const userName = presenceMap[userId] || profileNameMap[userId] || "";
+        return { itemId, userId, userName };
+      });
+
+      usePlanStore.getState().setEditingItems(resolved);
+    } else {
+      usePlanStore.getState().setEditingItems([]);
+    }
+  } else {
+    usePlanStore.getState().setEditingItems([]);
+  }
 
   const myProfile = await getMyProfile()
   usePresenceStore.getState().setMyProfile(myProfile)

--- a/src/router/loader/dashBoardLoader.ts
+++ b/src/router/loader/dashBoardLoader.ts
@@ -1,80 +1,98 @@
 // loaders/dashboardLoader.ts
-import { type LoaderFunctionArgs } from "react-router-dom"
-import { loadGroupData, type Group } from "@/pages/DashBoard/api/loadGroupData"
-import { loadPlanItems, type PlanItem } from "@/pages/DashBoard/api/loadPlanItem"
-import { useGroupStore } from "@/pages/DashBoard/store/groupStore"
-import { generateTripDays } from "@/pages/DashBoard/utils/generateTripDays"
-import { usePlanStore } from "@/pages/DashBoard/store/planStore"
-import { getMyProfile } from "@/pages/DashBoard/api/getMyProfile" 
-import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore"
-import { supabase } from "@/lib/supabaseClient"
+import { type LoaderFunctionArgs } from "react-router-dom";
+import { loadGroupData, type Group } from "@/pages/DashBoard/api/loadGroupData";
+import { loadPlanItems, type PlanItem } from "@/pages/DashBoard/api/loadPlanItem";
+import { useGroupStore } from "@/pages/DashBoard/store/groupStore";
+import { generateTripDays } from "@/pages/DashBoard/utils/generateTripDays";
+import { usePlanStore } from "@/pages/DashBoard/store/planStore";
+import { getMyProfile } from "@/pages/DashBoard/api/getMyProfile";
+import { usePresenceStore } from "@/pages/DashBoard/store/presenceStore";
+import { supabase } from "@/lib/supabaseClient";
 
 export type DashboardLoaderData = {
-  groupData: Group
-  planItems: PlanItem[] | null
+  groupData: Group;
+  planItems: PlanItem[] | null;
+};
+
+// ──────────────────────────────────────────────
+// Helper: DB에서 사용자 이름 가져오기
+async function fetchProfileNames(userIds: string[]): Promise<Record<string, string>> {
+  if (userIds.length === 0) return {};
+
+  const { data } = await supabase
+    .from("profile")
+    .select("id, name")
+    .in("id", userIds);
+
+  const result: Record<string, string> = {};
+  if (data) {
+    for (const row of data as Array<{ id: string; name: string }>) {
+      result[row.id] = row.name;
+    }
+  }
+  return result;
 }
 
+// Helper: planItems 기반으로 편집 목록 세팅
+async function syncEditingItems(allPlanItems: PlanItem[]) {
+  const editingPairs = allPlanItems
+    .filter((p) => p.editing !== null)
+    .map((p) => ({ itemId: p.id, userId: p.editing as string }));
+
+  if (editingPairs.length === 0) {
+    usePlanStore.getState().setEditingItems([]);
+    return;
+  }
+
+  const presenceMap = usePresenceStore.getState().onlineUsersById;
+  const uniqueUserIds = Array.from(new Set(editingPairs.map((e) => e.userId)));
+
+  // presence에 없는 유저만 DB에서 조회
+  const missingIds = uniqueUserIds.filter(
+    (uid) => !presenceMap[uid] || presenceMap[uid].trim() === ""
+  );
+  const profileNameMap = await fetchProfileNames(missingIds);
+
+  const resolved = editingPairs.map(({ itemId, userId }) => ({
+    itemId,
+    userId,
+    userName: presenceMap[userId] || profileNameMap[userId] || "",
+  }));
+
+  usePlanStore.getState().setEditingItems(resolved);
+}
+
+// ──────────────────────────────────────────────
+// Main Loader
 export async function dashboardLoader(
   { params }: LoaderFunctionArgs
 ): Promise<DashboardLoaderData | null> {
-  const groupId = params.groupId
-  if (!groupId) return null
+  const groupId = params.groupId;
+  if (!groupId) return null;
 
-  const groupData = await loadGroupData(groupId)
-  if (!groupData) return null
+  const groupData = await loadGroupData(groupId);
+  if (!groupData) return null;
 
-  // 전체 일정 데이터 로드
-  const allPlanItems = await loadPlanItems(groupId)
-  
-  // 여행 날짜 생성
-  const tripDays = generateTripDays(groupData.start_day, groupData.end_day)
+  // 일정 & 날짜 로드
+  const allPlanItems = await loadPlanItems(groupId);
+  const tripDays = generateTripDays(groupData.start_day, groupData.end_day);
 
   // 스토어 초기화
-  useGroupStore.getState().setGroup(groupData)
-  usePlanStore.getState().setTripDays(tripDays)
-  usePlanStore.getState().setSelectedDay(groupData.start_day)
-  usePlanStore.getState().setAllPlanItems(allPlanItems || [])
+  useGroupStore.getState().setGroup(groupData);
+  usePlanStore.getState().setTripDays(tripDays);
+  usePlanStore.getState().setSelectedDay(groupData.start_day);
+  usePlanStore.getState().setAllPlanItems(allPlanItems || []);
 
-  // DB의 editing 컬럼을 사용해 편집 목록 덮어쓰기
-  if (allPlanItems && allPlanItems.length > 0) {
-    const editingPairs = allPlanItems
-      .filter((p) => p.editing !== null)
-      .map((p) => ({ itemId: p.id, userId: p.editing as string }));
-
-    if (editingPairs.length > 0) {
-      const presenceMap = usePresenceStore.getState().onlineUsersById;
-      const uniqueUserIds = Array.from(new Set(editingPairs.map((e) => e.userId)));
-
-      // presence에 이름이 없는 사용자만 프로필에서 조회
-      const missingIds = uniqueUserIds.filter((uid) => !presenceMap[uid] || presenceMap[uid].trim() === "");
-      let profileNameMap: Record<string, string> = {};
-      if (missingIds.length > 0) {
-        const { data } = await supabase
-          .from("profile")
-          .select("id, name")
-          .in("id", missingIds);
-        if (data) {
-          for (const row of data as Array<{ id: string; name: string }>) {
-            profileNameMap[row.id] = row.name;
-          }
-        }
-      }
-
-      const resolved = editingPairs.map(({ itemId, userId }) => {
-        const userName = presenceMap[userId] || profileNameMap[userId] || "";
-        return { itemId, userId, userName };
-      });
-
-      usePlanStore.getState().setEditingItems(resolved);
-    } else {
-      usePlanStore.getState().setEditingItems([]);
-    }
+  // 편집 목록 동기화
+  if (allPlanItems) {
+    await syncEditingItems(allPlanItems);
   } else {
     usePlanStore.getState().setEditingItems([]);
   }
 
-  const myProfile = await getMyProfile()
-  usePresenceStore.getState().setMyProfile(myProfile)
+  // 내 프로필 동기화
+  const myProfile = await getMyProfile();
+  usePresenceStore.getState().setMyProfile(myProfile);
 
-  return null
+  return null;
 }

--- a/src/types/supabase.d.ts
+++ b/src/types/supabase.d.ts
@@ -197,6 +197,7 @@ export type Database = {
           address: string | null
           day: string
           duration: number
+          editing: string | null
           group_id: string
           id: string
           jitter: string | null
@@ -209,6 +210,7 @@ export type Database = {
           address?: string | null
           day: string
           duration?: number
+          editing?: string | null
           group_id: string
           id?: string
           jitter?: string | null
@@ -221,6 +223,7 @@ export type Database = {
           address?: string | null
           day?: string
           duration?: number
+          editing?: string | null
           group_id?: string
           id?: string
           jitter?: string | null


### PR DESCRIPTION
## 🌟 작업 개요
- 웹소켓 채널에 들어가지 않아도 채널 접속시 다른 팀원의 수정 상태를 동기화할 수 있습니다.
- 마이크로 애니메이션을 추가했습니다. 

## 📝 작업 내용
- planitems 테이블에 수정 여부 컬럼(editing)을 추가하여 로더에서 같이 불러와 초기 상태를 지정해 줍니당

## ‼️ 관련 이슈
<!-- 이슈 채널의 해시태그를 입력해주세요 예시) Closes #10 -->
Closes #108 